### PR TITLE
feature no smtp auth, bugfix header time&date

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,12 @@ the thresholds, the plugin searches through the mailbox until the critical thres
       `--imap-password=[IMAP_PASSWORD]`<br>
       `--smtp-host=[SMTP_HOST]`<br>
       `--smtp-port=[SMTP_PORT]`<br>
-      `--smtp-user=[SMTP_USERNAME]`<br>
-      `--smtp-password=[SMTP_PASSWORD]`<br>
       `--sender=[SENDER_ADDRESS]`<br>
       `--receiver=[RECEIVER_ADDRESS]`<br>
+
+**Optional arguments:**<br>
+      `--smtp-user=[SMTP_USERNAME]`<br>
+      `--smtp-password=[SMTP_PASSWORD]`<br>
 
 **If not otherwise specified, the default values will be applied:**<br>
       `--imap-port=993`<br>

--- a/check_email
+++ b/check_email
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# 'python' should point to python version 2.*
 
 try:
     import sys
@@ -114,7 +115,7 @@ class ImapConnection(object):
     # TODO: regex is very expensive
     # search an alternative solution
     def parse_received(raw_email_received):
-        email_server_date_as_unix = raw_email_received
+        email_server_date_as_unix = raw_email_received.replace("\n", ' ').replace("\r", ' ')
         match = re.search(r";\s(.*)", email_server_date_as_unix)
 
         if match:
@@ -211,7 +212,8 @@ class SmtpConnection(object):
         if self.mode == 'tls':
             self.smtpcon.starttls()
 
-        self.smtpcon.login(self.user, self.password)
+        if self.user:
+            self.smtpcon.login(self.user, self.password)
 
     def send(self):
         time_send = int(time.time())
@@ -249,12 +251,12 @@ def parse_arguments():
 
     parser.add_argument('--smtp-user', '-susr',
                         help='username for SMTP (default: (env SMTP_USERNAME))',
-                        required=not os.getenv('SMTP_USERNAME'),
+                        required=False,
                         default=os.getenv('SMTP_USERNAME'))
 
     parser.add_argument('--smtp-password', '-spw',
                         help='password for SMTP (default: (env SMTP_PASSWORD))',
-                        required=not os.getenv('SMTP_PASSWORD'),
+                        required=False,
                         default=os.getenv('SMTP_PASSWORD'))
 
     parser.add_argument('--smtp-mode',


### PR DESCRIPTION
New 'feature':
smtp-user and -pass are now optional. That allows sending mail through
servers that do not require/offer authentication (e.g. localhost).

Bugfix Received-Header:
Remove "\n\r" from header line. Otherwise, the programm crashes when date/time
are spread over multiple header lines

Updated documentation accordingly.